### PR TITLE
Ignore unnamed EC2 instance

### DIFF
--- a/lib/aws_ec2_dns_name.rb
+++ b/lib/aws_ec2_dns_name.rb
@@ -20,13 +20,15 @@ class AwsEc2DnsName
   def instances
     client.describe_instances.first.reservations.map do |reservation|
       ec2_instance = reservation.instances.first
-      name_tag = ec2_instance.tags.find { |tag| tag.key == "Name" }.value
+      name_tag = ec2_instance.tags.find { |tag| tag.key == "Name" }
+      next unless name_tag
+      name_tag_value = name_tag.value
       dns_name = dns_name(ec2_instance)
 
       # dns_name of terminated instance is empty string
       next if dns_name == ""
 
-      AwsEc2DnsName::Instance.new(name_tag, dns_name)
+      AwsEc2DnsName::Instance.new(name_tag_value, dns_name)
     end.compact.sort_by { |i| i[:name_tag] }
   end
   alias list instances


### PR DESCRIPTION
Problem
===

If any EC2 instance has no Name tag, aws_ec2_dns_name fails.

It is a part of the stack trace.

```console
NoMethodError: undefined method `value' for nil:NilClass
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/aws_ec2_dns_name-0.1.4/lib/aws_ec2_dns_name.rb:22:in `block in instances'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/aws_ec2_dns_name-0.1.4/lib/aws_ec2_dns_name.rb:20:in `map'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/aws_ec2_dns_name-0.1.4/lib/aws_ec2_dns_name.rb:20:in `instances'
```


Solution
===


Ignore EC2 instance if it does not have Name tag.