### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
-sudo: false
 language: ruby
 rvm:
-  - 2.4.0
-before_install:
-  - gem update --system
-  - gem install bundler -v 1.14.0
+  - 2.6.5
+  - 2.7.0

--- a/aws_ec2_dns_name.gemspec
+++ b/aws_ec2_dns_name.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "aws-sdk-ec2", "~> 1"
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", "< 3"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rubocop"


### PR DESCRIPTION
* Cleanup .travis.yml
  * `sudo: false` is no longer necessary
  * `gem update --system` is old way. It should be removed if CI is green without it.
* Update Ruby version
  * 2.5 or older are not used by us.
  * Currently we use 2.6, so we still support it.
  * We will use 2.7 in the future, so it also should be supported.